### PR TITLE
Added keybind and hover text to doors to toggle auto/manual. Added hotkey for mod enable/disable.

### DIFF
--- a/GameClasses/Door.cs
+++ b/GameClasses/Door.cs
@@ -36,9 +36,13 @@ namespace AutoDoors.GameClasses
             {
                 return;
             }
+
             var id = __instance.GetInstanceID();
             TrackedDoor foundDoor = AutoDoorPlugin.Instance.TrackedDoors.FirstOrDefault(td => td.Id == id);
-            __result += Localization.instance.Localize($"\n[<color=yellow><b>{AutoDoorPlugin.Instance.Cfg.ToggleKey}</b></color>+<color=yellow><b>$KEY_Use</b></color>] to set {(foundDoor.IsAutomatic ? "manual" : "automatic")}");
+            if (foundDoor.IsValid)
+            {
+                __result += Localization.instance.Localize($"\n[<color=yellow><b>{AutoDoorPlugin.Instance.Cfg.ToggleKey}</b></color>+<color=yellow><b>$KEY_Use</b></color>] to set {(foundDoor.IsAutomatic ? "manual" : "automatic")}");
+            }
         }
     }
 

--- a/GameClasses/Door.cs
+++ b/GameClasses/Door.cs
@@ -26,4 +26,46 @@ namespace AutoDoors.GameClasses
             }
         }
     }
+
+    [HarmonyPatch(typeof(Door), "GetHoverText")]
+    static class Door_GetHoverText_Patch
+    {
+        static void Postfix(Door __instance, ref string __result, ZNetView ___m_nview)
+        {
+            if (!AutoDoorPlugin.IsRunning || ___m_nview.GetZDO() == null)
+            {
+                return;
+            }
+            var id = __instance.GetInstanceID();
+            TrackedDoor foundDoor = AutoDoorPlugin.Instance.TrackedDoors.FirstOrDefault(td => td.Id == id);
+            __result += Localization.instance.Localize($"\n[<color=yellow><b>{AutoDoorPlugin.Instance.Cfg.ToggleKey}</b></color>+<color=yellow><b>$KEY_Use</b></color>] to set {(foundDoor.IsAutomatic ? "manual" : "automatic")}");
+        }
+    }
+
+    [HarmonyPatch(typeof(Door), "Interact")]
+    public static class Door_InteractState_Patch
+    {
+        static bool Prefix(Door __instance, ZNetView ___m_nview, Humanoid character)
+        {
+
+            if (!AutoDoorPlugin.IsRunning || !___m_nview.GetZDO().IsValid() || !(character is Player) || !Input.GetKey(AutoDoorPlugin.Instance.Cfg.ToggleKey))
+            {
+                return true;
+            }
+
+            if (AutoDoorPlugin.Instance.IsActive && __instance.m_keyItem == null)
+            {
+                var id = __instance.GetInstanceID();
+                TrackedDoor foundDoor = AutoDoorPlugin.Instance.TrackedDoors.FirstOrDefault(td => td.Id == id);
+                if (foundDoor.IsValid)
+                {
+                    foundDoor.IsAutomatic = !foundDoor.IsAutomatic;
+                    AutoDoorPlugin.InstanceLogger.LogInfo("Door set to " + (foundDoor.IsAutomatic ? "auto" : "manual"));
+                }
+                return false;
+            }
+
+            return true;
+        }
+    }
 }

--- a/GameClasses/Player.cs
+++ b/GameClasses/Player.cs
@@ -76,7 +76,7 @@ namespace AutoDoors.GameClasses
                                 }
                                 else
                                 {
-                                    if (!prevInAutoRange)
+                                    if (rangeChange)
                                     {
                                         td.IsManual = true;
                                         //AutoDoorPlugin.InstanceLogger.LogInfo($"winkio.autodoors - door {td.Id} is now manual 2");
@@ -88,7 +88,7 @@ namespace AutoDoors.GameClasses
                                 }
                             }
                         }
-                        else if (prevInAutoRange)
+                        else if (!rangeChange)
                         {
                             if (!td.IsManual)
                             {

--- a/GameClasses/Player.cs
+++ b/GameClasses/Player.cs
@@ -22,14 +22,13 @@ namespace AutoDoors.GameClasses
             if (player != __instance)
                 return;
 
-            var modEnabled = AutoDoorPlugin.Instance.Cfg.ModEnabled;
-            var modToggleChange = modEnabled;
             if (Input.GetKeyDown(AutoDoorPlugin.Instance.Cfg.EnableKey))
             {
-                AutoDoorPlugin.Instance.Cfg.ModEnabled = modEnabled = !modEnabled;
-                MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Auto Doors mod " + (modEnabled ? "enabled" : "disabled"));
+                AutoDoorPlugin.Instance.Cfg.ModEnabled = !AutoDoorPlugin.Instance.Cfg.ModEnabled;
+                MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, $"Auto Doors mod {(AutoDoorPlugin.Instance.Cfg.ModEnabled ? "enabled." : "disabled.")}");
             }
-            modToggleChange = modEnabled != modToggleChange;// detect the mod turning off or on
+            var modEnabled = AutoDoorPlugin.Instance.Cfg.ModEnabled.Equals(true);
+
 
             bool validPlayer = player != null && !player.IsDead();
             var timeNow = DateTime.UtcNow;
@@ -58,6 +57,8 @@ namespace AutoDoors.GameClasses
                         var dsq = Vector3.SqrMagnitude(d.transform.position - player.transform.position);
                         td.InAutoRange = dsq <= rsq;
                         var rangeChange = prevInAutoRange != td.InAutoRange;
+                        var modToggleChange = modEnabled != td.lastModState;
+                        td.lastModState = modEnabled;
 
                         if (modToggleChange)
                         {
@@ -69,7 +70,7 @@ namespace AutoDoors.GameClasses
                                 }
                             } 
                             else
-                            {//mod enabled
+                            {// mod enabled
                                 if (td.IsAutomatic)
                                 {// door is automatic
                                     if(td.State == 0 && td.InAutoRange)
@@ -93,8 +94,6 @@ namespace AutoDoors.GameClasses
                             }
                         }
 
-
-                        
                     }
 
                 }

--- a/GameClasses/Player.cs
+++ b/GameClasses/Player.cs
@@ -22,11 +22,14 @@ namespace AutoDoors.GameClasses
             if (player != __instance)
                 return;
 
+            var modEnabled = AutoDoorPlugin.Instance.Cfg.ModEnabled;
+            var modToggleChange = modEnabled;
             if (Input.GetKeyDown(AutoDoorPlugin.Instance.Cfg.ToggleKey))
             {
-                AutoDoorPlugin.Instance.Cfg.ModEnabled = !AutoDoorPlugin.Instance.Cfg.ModEnabled;
-                MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Auto Doors mod " + (AutoDoorPlugin.Instance.Cfg.ModEnabled ? "enabled" : "disabled"));
+                AutoDoorPlugin.Instance.Cfg.ModEnabled = modEnabled = !modEnabled;
+                MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Auto Doors mod " + (modEnabled ? "enabled" : "disabled"));
             }
+            modToggleChange = modEnabled != modToggleChange;// detect the mod turning off or on
 
             bool validPlayer = player != null && !player.IsDead();
             var timeNow = DateTime.UtcNow;
@@ -51,9 +54,10 @@ namespace AutoDoors.GameClasses
                     var obj = UnityEngine.Object.FindObjectFromInstanceID(td.Id);
                     if (obj is Door d)
                     {
-                        var prevInAutoRange = td.InAutoRange;
+                        var rangeChange = td.InAutoRange;
                         var dsq = Vector3.SqrMagnitude(d.transform.position - player.transform.position);
                         td.InAutoRange = dsq <= rsq;
+                        rangeChange = rangeChange != td.InAutoRange;// detect changes in player proximity to door
                         if (td.InAutoRange)
                         {
                             if (!td.IsManual)

--- a/GameClasses/Player.cs
+++ b/GameClasses/Player.cs
@@ -22,6 +22,12 @@ namespace AutoDoors.GameClasses
             if (player != __instance)
                 return;
 
+            if (Input.GetKeyDown(AutoDoorPlugin.Instance.Cfg.ToggleKey))
+            {
+                AutoDoorPlugin.Instance.Cfg.ModEnabled = !AutoDoorPlugin.Instance.Cfg.ModEnabled;
+                MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Auto Doors mod " + (AutoDoorPlugin.Instance.Cfg.ModEnabled ? "enabled" : "disabled"));
+            }
+
             bool validPlayer = player != null && !player.IsDead();
             var timeNow = DateTime.UtcNow;
             bool updateIntervalPassed = (timeNow - AutoDoorPlugin.Instance.LastUpdate).TotalSeconds >= AutoDoorPlugin.Instance.Cfg.UpdateInterval;

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -53,11 +53,11 @@ namespace AutoDoors
 
             var config = AutoDoorPlugin.Instance.Config;
 
-            modEnabled = config.Bind("General", "modEnabled", true, "Enables the mod");
-            enableKey = config.Bind("General", "enableKey", KeyCode.F6, "Press to toggle auto doors mod on/off.");
-            toggleKey = config.Bind("General", "toggleKey", KeyCode.LeftAlt, "Hold while interacting with the door to toggle between auto/manual.");
-            updateInterval = config.Bind("General", "updateInterval", 1f/16, "Minimum interval between updates (s)");
-            disableInCrypt = config.Bind("General", "disableInCrypt", true, "Disables auto doors inside crypts");
+            modEnabled = config.Bind("General", "Mod Enabled", true, "Enables the mod");
+            enableKey = config.Bind("General", "Enable Key", KeyCode.F6, "Press to toggle auto doors mod on/off.");
+            toggleKey = config.Bind("General", "Toggle Key", KeyCode.LeftAlt, "Hold while interacting with the door to toggle between auto/manual.");
+            updateInterval = config.Bind("General", "Update Interval", 1f/16, "Minimum interval between updates (s)");
+            disableInCrypt = config.Bind("General", "Disable In Crypt", true, "Disables auto doors inside crypts");
         }
 
         #endregion

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -4,12 +4,25 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace AutoDoors
 {
     public class PluginConfig
     {
         #region Properties - General
+
+        /// <summary>
+        /// Enables the mod
+        /// </summary>
+        public bool ModEnabled { get => modEnabled.Value; set => modEnabled.BoxedValue = value; }
+        ConfigEntry<bool> modEnabled;
+
+        /// <summary>
+        /// Key that toggles the mod
+        /// </summary>
+        public KeyCode ToggleKey { get => toggleKey.Value; }
+        ConfigEntry<KeyCode> toggleKey;
 
         /// <summary>
         /// Minimum interval between updates (s)
@@ -34,6 +47,8 @@ namespace AutoDoors
 
             var config = AutoDoorPlugin.Instance.Config;
 
+            modEnabled = config.Bind("General", "modEnabled", true, "Enable this mod");
+            toggleKey = config.Bind("General", "toggleKey", KeyCode.F6, "Press to toggle auto doors on/off.");
             updateInterval = config.Bind("General", "updateInterval", 1f/16, "Minimum interval between updates (s)");
             disableInCrypt = config.Bind("General", "disableInCrypt", true, "Disables auto doors inside crypts");
         }

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -19,7 +19,13 @@ namespace AutoDoors
         ConfigEntry<bool> modEnabled;
 
         /// <summary>
-        /// Key that toggles the mod
+        /// Press to toggle auto doors mod on/off.
+        /// </summary>
+        public KeyCode EnableKey { get => enableKey.Value; }
+        ConfigEntry<KeyCode> enableKey;
+
+        /// <summary>
+        /// Hold while interacting with the door to toggle between auto/manual.
         /// </summary>
         public KeyCode ToggleKey { get => toggleKey.Value; }
         ConfigEntry<KeyCode> toggleKey;
@@ -47,8 +53,9 @@ namespace AutoDoors
 
             var config = AutoDoorPlugin.Instance.Config;
 
-            modEnabled = config.Bind("General", "modEnabled", true, "Enable this mod");
-            toggleKey = config.Bind("General", "toggleKey", KeyCode.F6, "Press to toggle auto doors on/off.");
+            modEnabled = config.Bind("General", "modEnabled", true, "Enables the mod");
+            enableKey = config.Bind("General", "enableKey", KeyCode.F6, "Press to toggle auto doors mod on/off.");
+            toggleKey = config.Bind("General", "toggleKey", KeyCode.LeftAlt, "Hold while interacting with the door to toggle between auto/manual.");
             updateInterval = config.Bind("General", "updateInterval", 1f/16, "Minimum interval between updates (s)");
             disableInCrypt = config.Bind("General", "disableInCrypt", true, "Disables auto doors inside crypts");
         }

--- a/TrackedDoor.cs
+++ b/TrackedDoor.cs
@@ -15,15 +15,14 @@ namespace AutoDoors
         public bool IsValid { get; private set; } = true;
 
         public bool InAutoRange { get; set; }
-        public bool IsManual { get; set; }
-        public bool IsAutoOpened { get; set; }
+        public bool IsAutomatic { get; set; }
 
         public TrackedDoor(int id, ZNetView zNetView)
         {
             Id = id;
             ZNetView = zNetView;
             Update();
-            IsManual = State != 0;
+            IsAutomatic = State == 0;
         }
 
         public bool Update()

--- a/TrackedDoor.cs
+++ b/TrackedDoor.cs
@@ -16,6 +16,7 @@ namespace AutoDoors
 
         public bool InAutoRange { get; set; }
         public bool IsAutomatic { get; set; }
+        public bool lastModState { get; set; }
 
         public TrackedDoor(int id, ZNetView zNetView)
         {
@@ -23,6 +24,7 @@ namespace AutoDoors
             ZNetView = zNetView;
             Update();
             IsAutomatic = State == 0;
+            lastModState = AutoDoorPlugin.Instance.Cfg.ModEnabled.Equals(true);
         }
 
         public bool Update()


### PR DESCRIPTION
Door.cs: Added PostFix for GetHoverText to add the interaction prompt for setting the door auto or manual. The default keybind is LeftAlt + the use key (E). Also added the Prefix to Interact to toggle between auto and manual.
![DoorHoverText](https://github.com/winkio/Valheim_AutoDoors/assets/12423043/fca903f0-60e5-49e0-bc42-7fad22d9b347)

Player.cs: I had to rewrite the logic to incorporate the auto/manual and mod enable/disable features, but those 'if statements' are well commented so it should be easy to make changes if needed.

PluginCofig.cs: Added more config bindings for the added features.

TrackedDoor.cs: Modifications to the variables to work with the new features.